### PR TITLE
Improve docs with bullet points and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ Hardware Agnostic AS5047U library - as used in the HardFOC-V1 controller
 
 ## 📦 Overview
 **HF-AS5047U** is a portable C++20 driver for the **AS5047U** magnetic encoder from ams. It delivers fast 14‑bit absolute angle readings over SPI, optional CRC protection and advanced features like Dynamic Angle Error Compensation (DAEC) and an adaptive Dynamic Filter System (DFS™). The sensor can also output incremental (A/B/I) and 3‑phase commutation (UVW) signals or a PWM encoded angle, making it a drop‑in replacement for optical encoders in high-performance motor control and robotics.
+### ✨ Key Features
+- 🧩 Cross-platform `spiBus` interface
+- 📐 Modern C++20 API
+- 📝 Examples for Arduino, ESP32 and STM32
+- 🧪 Unit tests for reliability
 
 ## 🚀 Sensor Highlights
 * **14‑bit absolute angle** with optional CRC check
@@ -114,49 +119,47 @@ Detailed step‑by‑step guides (with example command output) are available in 
 ---
 
 ## 🔧 Installation
-1. Copy `AS5047U.hpp`, `AS5047U.cpp` and `AS5047U_REGISTERS.hpp` into your project.
-2. Implement the `spiBus` interface for your platform.
-3. Include the header: `#include "AS5047U.hpp"`.
-4. Compile with a **C++20** or newer compiler.
-5. Optionally build using the provided `Makefile`.
-   Compiler flags can be overridden on the command line. Configuration
-   options such as default SPI frame format and CRC retries can be set
-   through `Kconfig` or by editing `AS5047U_config.hpp`.
+- 📥 Copy `AS5047U.hpp`, `AS5047U.cpp` and `AS5047U_REGISTERS.hpp` into your project
+- 🔌 Implement the `spiBus` interface for your platform
+- ➕ `#include "AS5047U.hpp"`
+- 🛠️ Compile with a **C++20** compiler
+- 🏗️ Optionally build with the provided `Makefile`
+  - Override compiler flags on the command line
+  - Configure default options via `Kconfig` or `AS5047U_config.hpp`
 
 ---
 
 ## 🧠 Quick Start
 
 ```cpp
-AS5047U encoder(bus, FrameFormat::SPI_24);
+AS5047U encoder(bus, FrameFormat::SPI_24); // driver using 24-bit frames
 
-uint16_t angle = encoder.getAngle();
-uint16_t rawAngle = encoder.getRawAngle();
-int16_t vel = encoder.getVelocity();
-double vel_dps = encoder.getVelocityDegPerSec();
+uint16_t angle = encoder.getAngle();        // compensated angle
+uint16_t rawAngle = encoder.getRawAngle();  // raw angle without DAEC
+int16_t vel = encoder.getVelocity();        // velocity in sensor units
+double vel_dps = encoder.getVelocityDegPerSec(); // velocity in deg/s
 
-uint8_t agc = encoder.getAGC();
-uint16_t mag = encoder.getMagnitude();
-uint16_t errors = encoder.getErrorFlags();
+uint8_t agc = encoder.getAGC();             // automatic gain control
+uint16_t mag = encoder.getMagnitude();      // magnetic magnitude
+uint16_t errors = encoder.getErrorFlags();  // current error flags
 ```
 
 Configure outputs:
 ```cpp
-encoder.setZeroPosition(8192);
-encoder.setDirection(false);
-encoder.setABIResolution(12);
-encoder.setUVWPolePairs(5);
-encoder.configureInterface(true, false, true);
+encoder.setZeroPosition(8192);            // set zero electrical angle
+encoder.setDirection(false);              // counter-clockwise = positive
+encoder.setABIResolution(12);             // 12-bit incremental output
+encoder.setUVWPolePairs(5);               // 5 electrical pole pairs
+encoder.configureInterface(true, false, true); // enable ABI + PWM
 ```
-
 Perform OTP programming:
 ```cpp
-bool ok = encoder.programOTP();
+bool ok = encoder.programOTP();  // write settings to OTP
 ```
 
 Dump diagnostics:
 ```cpp
-std::string status = encoder.dumpDiagnostics();
+std::string status = encoder.dumpDiagnostics(); // formatted status text
 ```
 
 ## ⚙️ Configuration

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,10 +2,10 @@
 
 Welcome! This directory contains step‑by‑step guides for installing, building and using the **HF-AS5047U** library. Each guide focuses on a specific topic and is meant to be read in order. Example output is provided so you know what to expect when commands run correctly.
 
-- [Setup](setup.md) – prerequisites and how to obtain the source
-- [Building and Testing](building.md) – compile the library and run the unit tests
-- [Using the Library](usage.md) – integrate the driver in your own project
-- [Running the Examples](examples.md) – compile and upload the example sketches
-- [Quick Start Workflow](workflow.md) – everything from cloning to running examples
+- 📥 [Setup](setup.md) – prerequisites and how to obtain the source
+- 🛠️ [Building and Testing](building.md) – compile the library and run the unit tests
+- 🧩 [Using the Library](usage.md) – integrate the driver in your own project
+- 🚀 [Running the Examples](examples.md) – compile and upload the example sketches
+- 🏃 [Quick Start Workflow](workflow.md) – everything from cloning to running examples
 
 Use the links above to navigate to each section.

--- a/docs/building.md
+++ b/docs/building.md
@@ -1,19 +1,13 @@
-# Building and Testing
+# 🧰 Building and Testing
 
 This guide explains how to compile the library and run the provided unit tests.
 
 ## Building the Static Library
 
-Run the supplied `Makefile` to build `libas5047u.a`:
+- 🔨 Run `make lib` to build `libas5047u.a`
+- 🧹 Use `make clean` before rebuilding
 
-```bash
-make lib
-```
-
-If you want to rebuild from scratch, run `make clean` first.
-
-The archive will be placed in the project root and you should see output similar to:
-
+The archive will be placed in the project root. Typical output:
 ```
 g++ -I./src -I. -std=c++20 -Wall -Wextra -pedantic -O2 -c src/AS5047U.cpp -o src/AS5047U.o
 ar rcs libas5047u.a src/AS5047U.o
@@ -22,17 +16,8 @@ ar rcs libas5047u.a src/AS5047U.o
 Object files are generated in the `src` directory.
 
 ## Running the Unit Tests
+- 🏃 `make test` builds and runs `unit_tests`
+  - Expect `All tests passed` on success
 
-Compile and execute the tests using:
-
-```bash
-make test
-```
-
-The build creates an executable named `unit_tests` and runs it automatically.  A successful run prints:
-
-```
-All tests passed
-```
 
 If the build fails ensure your compiler supports C++20 and that `make` is installed.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,41 +1,35 @@
-# Running the Examples
+# 🎮 Running the Examples
 
 Example projects for Arduino, ESP32 (ESP-IDF) and STM32 are provided in the `examples` directory.
 
 ## Arduino
 
-1. Open `examples/arduino_basic_interface/main.ino` in the Arduino IDE.
-2. Adjust the pin numbers at the top of the sketch to match your wiring.
-3. Select your board and COM port.
-4. Compile and upload the sketch.
-5. Open the serial monitor to view angle and diagnostic output.
-   You should see lines similar to:
-
-   ```
-   [Angle] 12345 LSB (67.89°)
-   [Diag] AGC=128  MAG=16000
-   ```
+- 📂 Open `examples/arduino_basic_interface/main.ino` in the Arduino IDE
+- 🔧 Adjust the pin numbers to match your wiring
+- 🚀 Compile and upload the sketch
+- 🖥️ Open the serial monitor to view angle output
+  ```
+  [Angle] 12345 LSB (67.89°)
+  [Diag] AGC=128  MAG=16000
+  ```
 
 ## ESP32 (ESP-IDF)
 
-1. Copy the contents of `examples/es32_basic_interface` into an ESP-IDF project.
-2. Implement an `spiBus` using ESP-IDF's SPI API as shown in `app_main.cpp`.
-3. Build and flash using `idf.py flash monitor`.
-   The monitor will print the angle repeatedly, for example:
-
-   ```
-   Angle: 90.0 deg
-   ```
+- 📂 Copy `examples/es32_basic_interface` into an ESP-IDF project
+- 🔧 Implement an `spiBus` using ESP-IDF SPI API
+- 🚀 Build and flash using `idf.py flash monitor`
+  ```
+  Angle: 90.0 deg
+  ```
 
 ## STM32 HAL
 
-1. Import `examples/stm32_basic_interface` into your STM32CubeIDE workspace.
-2. Wire the sensor to an SPI peripheral and adjust the pin definitions in `app_encoder_init.cpp`.
-3. Build the project and flash your board.
-4. Open the UART console to observe output similar to:
-
-   ```
-   Angle: 45 deg
-   ```
+- 📂 Import `examples/stm32_basic_interface` into STM32CubeIDE
+- 🔧 Wire the sensor and adjust pins in `app_encoder_init.cpp`
+- 🚀 Build and flash your board
+- 🖥️ Open the UART console to see:
+  ```
+  Angle: 45 deg
+  ```
 
 Each example demonstrates basic angle reading and can be extended to suit your application.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,12 +1,12 @@
-# Setup
+# 🛠️ Setup
 
 This guide walks you through preparing your environment and cloning the repository.
 
 ## Prerequisites
 
-- **C++20 compiler** (e.g. `g++` 10 or later)
-- **Make** utility
-- **Git** for cloning the sources
+- ✅ **C++20 compiler** (e.g. `g++` 10+)
+- ✅ **Make** utility
+- ✅ **Git** for cloning the sources
 
 These packages are available on most Linux distributions. On Debian/Ubuntu you can install them with:
 
@@ -18,7 +18,7 @@ sudo apt-get install build-essential git
 Verify that `g++` supports C++20:
 
 ```bash
-g++ --version
+g++ --version   # should report version 10 or later
 ```
 
 ## Cloning the Repository

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,4 +1,4 @@
-# Using the Library
+# 📚 Using the Library
 
 This document shows how to integrate `HF-AS5047U` into your own project.
 
@@ -33,8 +33,8 @@ private:
 Pass your bus implementation and desired frame format to the constructor:
 
 ```cpp
-ArduinoBus bus(SPI, CS_PIN);
-AS5047U encoder(bus, FrameFormat::SPI_24);
+ArduinoBus bus(SPI, CS_PIN);                 // platform SPI wrapper
+AS5047U encoder(bus, FrameFormat::SPI_24);    // use 24-bit frames
 ```
 
 ## 3. Read Data
@@ -56,7 +56,7 @@ AGC: 128
 You can also read velocity in degrees per second:
 
 ```cpp
-double velDeg = encoder.getVelocityDegPerSec();
+double velDeg = encoder.getVelocityDegPerSec(); // velocity in deg/s
 ```
 
 Which might print something like `Velocity: 30.5 deg/s`.

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -1,44 +1,35 @@
-# Quick Start Workflow
-
+# 🏁 Quick Start Workflow
 Follow these steps to go from a fresh clone to running the example code.
 
-1. **Setup** – install `g++`, `make` and `git`. On Debian/Ubuntu:
-   ```bash
-   sudo apt-get update
-   sudo apt-get install build-essential git
-   ```
-   Verify the compiler works:
-   ```bash
-   g++ --version
-   ```
 
-2. **Clone the repository**
-   ```bash
-   git clone https://github.com/N3b3x/HF-AS5047U.git
-   cd HF-AS5047U
-   ```
-
-3. **Build the library**
-   ```bash
-   make lib
-   ```
-   Successful output ends with something like:
-   ```
-   ar rcs libas5047u.a src/AS5047U.o
-   ```
-
-4. **Run the unit tests**
-   ```bash
-   make test
-   ```
-   Expect to see `All tests passed`.
-
-5. **Integrate the driver** – create an `spiBus` as shown in [Using the Library](usage.md) and link against `libas5047u.a` in your project.
-
-6. **Try the examples**
-   ```bash
-   cd examples/arduino_basic_interface
-   # open `main.ino` in the Arduino IDE and upload
-   ```
-   The serial monitor should show angle readings similar to `Angle: 16384`.
-
+- 🛠️ **Setup** – install `g++`, `make` and `git` (Debian/Ubuntu example)
+  ```bash
+  sudo apt-get update
+  sudo apt-get install build-essential git
+  g++ --version
+  ```
+- 📥 **Clone** the repository
+  ```bash
+  git clone https://github.com/N3b3x/HF-AS5047U.git
+  cd HF-AS5047U
+  ```
+- 🔨 **Build** the library
+  ```bash
+  make lib
+  ```
+  Typical output:
+  ```
+  ar rcs libas5047u.a src/AS5047U.o
+  ```
+- ✅ **Run the unit tests**
+  ```bash
+  make test
+  ```
+  Expect `All tests passed`.
+- 🧩 **Integrate** the driver as shown in [Using the Library](usage.md) and link against `libas5047u.a` in your project.
+- 🚀 **Try the examples**
+  ```bash
+  cd examples/arduino_basic_interface
+  # open `main.ino` in the Arduino IDE and upload
+  ```
+  The serial monitor should show angle readings similar to `Angle: 16384`.


### PR DESCRIPTION
## Summary
- highlight key features in the main README
- expand the quick start code comments
- simplify installation steps
- add emojis and bullets throughout the docs
- rewrite examples and quick-start workflow for clarity

## Testing
- `make test` *(fails: Segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_e_6841f60d37388328824e04dbf693a9ba